### PR TITLE
Fixed Errors, added clear methods

### DIFF
--- a/examples/test.js
+++ b/examples/test.js
@@ -1,4 +1,4 @@
-var PixelPusher = require('./pixelpusher');
+var PixelPusher = require('../pixelpusher');
 var PixelStrip = PixelPusher.PixelStrip;
 
 new PixelPusher().on('discover', function(controller) {
@@ -23,7 +23,6 @@ new PixelPusher().on('discover', function(controller) {
         console.log('TIMEOUT : PixelPusher at address [' + controller.params.ipAddress + '] with MAC (' + controller.params.macAddress + ') has timed out. Awaiting re-discovery....');
         if (!!timer) clearInterval(timer);
     });
-
     // aquire the number of strips that the controller has said it
     // has connected via the pixel.rc config file
     var NUM_STRIPS = controller.params.pixelpusher.numberStrips;
@@ -35,50 +34,47 @@ new PixelPusher().on('discover', function(controller) {
     var PIXELS_PER_STRIP = controller.params.pixelpusher.pixelsPerStrip;
 
     // create a loop that will send commands to the PP to update the strip
-    var UPDATE_FREQUENCY_MILLIS = 30;// 15 is just faster than 60 FPS
-
-    var waveHeight = PIXELS_PER_STRIP/2;
-    var waveWidth = 10;
-    var wavePosition = 0;
+    var UPDATE_FREQUENCY_MILLIS = 30; // 15 is just faster than 60 FPS
 
 
     timer = setInterval(function() {
         // create an array to hold the data for all the strips at once
         // loop
         var strips = [];
-        for (var stripId = 0; stripId< NUM_STRIPS; stripId ++){
+        for (var i = 0; i < NUM_STRIPS; i ++){
+            var stripId = i;
             var s = new PixelStrip(stripId,PIXELS_PER_STRIP);
 
-            var startIdx = waveHeight+wavePosition;
-            for (var i = startIdx, j = waveWidth; i <PIXELS_PER_STRIP &&  i > waveHeight && j > 0; i --, j--){
-                // right wave
-                var p = s.getPixel(i);
-                p.setColor(255,0,0,(j/waveWidth));
+            // this sets random pixels on for each strip
+            // it also does a different color for wach of the 4 strips
+            /*
+            if (i == 0 || i == 4){
+                s.getRandomPixel().setColor(255,0,0, 0.1);
+            } else if (i == 1 || i == 5){
+                s.getRandomPixel().setColor(0,255,0, 0.1);
+            } else if (i == 2 || i == 6){
+                s.getRandomPixel().setColor(0,0,255, 0.1);
+            } else if (i == 3 || i == 7){
+                s.getRandomPixel().setColor(100,0,55, 0.1);
             }
+            */
 
-            var startIdx = waveHeight-wavePosition;
-            for (var i = startIdx, j = waveWidth; i > 0 &&  i < waveHeight && j > 0; i ++, j--){
-                // right wave
-                var p = s.getPixel(i);
-                p.setColor(255,0,0,(j/waveWidth));
-            }
+            s.getRandomPixel().setColor(255,0,0, 0.1);
+            // set the whole strip blue
 
-            // to show combined systems also set a random pixel blue
-            // set a random pixel blue
-            s.getRandomPixel().setColor(0,0,255, 0.1);
             // render the strip data into the correct format for sending
             // to the pixel pusher controller
             var renderedStripData = s.getStripData();
             // add this data to our list of strip data to send
             strips.push(renderedStripData);
         }
+
+        //console.log(strips.length)
+
         // inform the controller of the new strip frame
         controller.refresh(strips);
 
-        wavePosition = (wavePosition + 1) % waveHeight;
-
     }, UPDATE_FREQUENCY_MILLIS);
-
 }).on('error', function(err) {
   console.log('PixelPusher Error: ' + err.message);
 });

--- a/examples/test2.js
+++ b/examples/test2.js
@@ -1,4 +1,4 @@
-var PixelPusher = require('./pixelpusher');
+var PixelPusher = require('../pixelpusher');
 var PixelStrip = PixelPusher.PixelStrip;
 
 new PixelPusher().on('discover', function(controller) {
@@ -23,6 +23,7 @@ new PixelPusher().on('discover', function(controller) {
         console.log('TIMEOUT : PixelPusher at address [' + controller.params.ipAddress + '] with MAC (' + controller.params.macAddress + ') has timed out. Awaiting re-discovery....');
         if (!!timer) clearInterval(timer);
     });
+
     // aquire the number of strips that the controller has said it
     // has connected via the pixel.rc config file
     var NUM_STRIPS = controller.params.pixelpusher.numberStrips;
@@ -34,48 +35,50 @@ new PixelPusher().on('discover', function(controller) {
     var PIXELS_PER_STRIP = controller.params.pixelpusher.pixelsPerStrip;
 
     // create a loop that will send commands to the PP to update the strip
-    var UPDATE_FREQUENCY_MILLIS = 30; // 15 is just faster than 60 FPS
+    var UPDATE_FREQUENCY_MILLIS = 30;// 15 is just faster than 60 FPS
+
+    var waveHeight = PIXELS_PER_STRIP/2;
+    var waveWidth = 10;
+    var wavePosition = 0;
 
 
     timer = setInterval(function() {
         // create an array to hold the data for all the strips at once
         // loop
         var strips = [];
-        for (var i = 0; i < NUM_STRIPS; i ++){
-            var stripId = i;
+        for (var stripId = 0; stripId< NUM_STRIPS; stripId ++){
             var s = new PixelStrip(stripId,PIXELS_PER_STRIP);
 
-            // this sets random pixels on for each strip
-            // it also does a different color for wach of the 4 strips
-            /*
-            if (i == 0 || i == 4){
-                s.getRandomPixel().setColor(255,0,0, 0.1);
-            } else if (i == 1 || i == 5){
-                s.getRandomPixel().setColor(0,255,0, 0.1);
-            } else if (i == 2 || i == 6){
-                s.getRandomPixel().setColor(0,0,255, 0.1);
-            } else if (i == 3 || i == 7){
-                s.getRandomPixel().setColor(100,0,55, 0.1);
+            var startIdx = waveHeight+wavePosition;
+            for (var i = startIdx, j = waveWidth; i <PIXELS_PER_STRIP &&  i > waveHeight && j > 0; i --, j--){
+                // right wave
+                var p = s.getPixel(i);
+                p.setColor(255,0,0,(j/waveWidth));
             }
-            */
 
-            //s.getRandomPixel().setColor(255,0,0, 0.1);
-            // set the whole strip blue
-            s.setStripColor(0,255,255, 0.01);
+            var startIdx = waveHeight-wavePosition;
+            for (var i = startIdx, j = waveWidth; i > 0 &&  i < waveHeight && j > 0; i ++, j--){
+                // right wave
+                var p = s.getPixel(i);
+                p.setColor(255,0,0,(j/waveWidth));
+            }
 
+            // to show combined systems also set a random pixel blue
+            // set a random pixel blue
+            s.getRandomPixel().setColor(0,0,255, 0.1);
             // render the strip data into the correct format for sending
             // to the pixel pusher controller
             var renderedStripData = s.getStripData();
             // add this data to our list of strip data to send
             strips.push(renderedStripData);
         }
-
-        //console.log(strips.length)
-
         // inform the controller of the new strip frame
         controller.refresh(strips);
 
+        wavePosition = (wavePosition + 1) % waveHeight;
+
     }, UPDATE_FREQUENCY_MILLIS);
+
 }).on('error', function(err) {
   console.log('PixelPusher Error: ' + err.message);
 });

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "node"         : ">=0.8"
     },
     "dependencies"   : {
-        "buffertools"  : "2.1.2"
+        "buffertools"  : "2.1.4"
     },
     "readmeFilename" : "README.md",
     "license": "MIT"

--- a/pixelpusher.js
+++ b/pixelpusher.js
@@ -382,19 +382,19 @@ Controller.prototype.trimStaleMessages = function(controller) {
 };
 
 Controller.prototype.clearStrips = function() {
-    const NUM_STRIPS = this.params.pixelpusher.numberStrips
-    const PIXELS_PER_STRIP = this.params.pixelpusher.pixelsPerStrip
+    var NUM_STRIPS = this.params.pixelpusher.numberStrips
+    var PIXELS_PER_STRIP = this.params.pixelpusher.pixelsPerStrip
     
     for (var i = 0; i < 2; i++) {
         if (typeof NUM_STRIPS != "number" || typeof PIXELS_PER_STRIP != "number") {
             throw new Error("Cannot find pixels per strip or number of strips")
         }
 
-        const strips = [];
+        var strips = [];
         for (var stripId = 0; stripId < NUM_STRIPS; stripId++) {
-            const s = new PixelStrip(stripId, PIXELS_PER_STRIP);
+            var s = new PixelStrip(stripId, PIXELS_PER_STRIP);
             s.clear()
-            const renderedStripData = s.getStripData();
+            var renderedStripData = s.getStripData();
             strips.push(renderedStripData);
         }
         this.refresh(strips);

--- a/pixelpusher.js
+++ b/pixelpusher.js
@@ -212,6 +212,7 @@ util.inherits(Controller, Emitter);
 Controller.prototype.refresh = function(strips) {
     var i,j, m, n, numbers, offset;
 
+
     var packet = null;
     var stripId = null;
     var that = this;
@@ -229,7 +230,8 @@ Controller.prototype.refresh = function(strips) {
         }
 
         // filter out sending dup data
-        if (that.currentStripData.length>0 && buffertools.equals(strips[i].data, that.currentStripData[i].data)) {
+        if (typeof that.currentStripData[i] != "undefined" || 
+            (that.currentStripData.length > 0 && buffertools.equals(strips[i].data, that.currentStripData[i].data))) {
             continue;
         }
 
@@ -378,6 +380,26 @@ Controller.prototype.trimStaleMessages = function(controller) {
     // simple trim to the latest 2 packets
     controller.messages = controller.messages.slice(0,2);
 };
+
+Controller.prototype.clearStrips = function() {
+    const NUM_STRIPS = this.params.pixelpusher.numberStrips
+    const PIXELS_PER_STRIP = this.params.pixelpusher.pixelsPerStrip
+    
+    for (var i = 0; i < 2; i++) {
+        if (typeof NUM_STRIPS != "number" || typeof PIXELS_PER_STRIP != "number") {
+            throw new Error("Cannot find pixels per strip or number of strips")
+        }
+
+        const strips = [];
+        for (var stripId = 0; stripId < NUM_STRIPS; stripId++) {
+            const s = new PixelStrip(stripId, PIXELS_PER_STRIP);
+            s.clear()
+            const renderedStripData = s.getStripData();
+            strips.push(renderedStripData);
+        }
+        this.refresh(strips);
+    }
+}
 
 PixelPusher.PixelStrip = PixelStrip;
 PixelPusher.Pixel = Pixel;

--- a/pixelstrip.js
+++ b/pixelstrip.js
@@ -14,6 +14,11 @@ module.exports = function(stripId, numPixels) {
         pixels.push(new Pixel());
     }
 
+    this.clear = function() {
+        for (var i = 0; i < NUM_PIXELS; i ++){
+            pixels[i].setColor(0, 0, 0, 0);
+        }
+    }
 
     this.setStripColor = function(r, g, b, a){
         for (var i = 0; i < NUM_PIXELS; i ++){


### PR DESCRIPTION
This PR introduces the following changes:
- Updates buffertools dep version which otherwise causes an error
- Adds check to ignore undefined strip slots while refreshing strip data
- Adds .clear() method to PixelStrip, which sets all pixels to color (0, 0, 0, 0), and .clearStrips() to the PixelPusher controller which clears every strip on the controller.