### PR TITLE
Remove buffertools

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name"           : "heroic-pixel-pusher",
-    "version"        : "0.2.4",
+    "version"        : "0.3.0",
     "description"    : "Heroic Robotics' Pixel Pusher LED controller node js interface",
     "author"         : "Aaron Jones <aaron@inburst.io>",
     "contributors"         : [
@@ -24,7 +24,7 @@
     ],
     "main"           : "./pixelpusher.js",
     "engines"        : {
-        "node"         : ">=0.11"
+        "node"         : ">=5.10"
     },
     "dependencies"   : {},
     "readmeFilename" : "README.md",

--- a/package.json
+++ b/package.json
@@ -24,11 +24,9 @@
     ],
     "main"           : "./pixelpusher.js",
     "engines"        : {
-        "node"         : ">=0.8"
+        "node"         : ">=0.11"
     },
-    "dependencies"   : {
-        "buffertools"  : "2.1.4"
-    },
+    "dependencies"   : {},
     "readmeFilename" : "README.md",
     "license": "MIT"
 }

--- a/pixelpusher.js
+++ b/pixelpusher.js
@@ -3,8 +3,7 @@
 // Aaron Jones <aaron@inburst.io>
 //******************************************************************************
 
-var buffertools = require('buffertools'),
-    dgram       = require('dgram'),
+var dgram       = require('dgram'),
     Emitter     = require('events').EventEmitter,
     util        = require('util');
 
@@ -231,7 +230,7 @@ Controller.prototype.refresh = function(strips) {
 
         // filter out sending dup data
         if (typeof that.currentStripData[i] != "undefined" || 
-            (that.currentStripData.length > 0 && buffertools.equals(strips[i].data, that.currentStripData[i].data))) {
+            (that.currentStripData.length > 0 && strips[i].data.equals( that.currentStripData[i].data ))) {
             continue;
         }
 

--- a/pixelpusher.js
+++ b/pixelpusher.js
@@ -201,7 +201,7 @@ var Controller = function(params) {
     for (i = 0; i < that.params.pixelpusher.numberStrips; i++) {
         that.currentStripData.push({
             strip_id : i,
-            data : new Buffer(0)
+            data : Buffer.alloc(0)
         });
     }
 };
@@ -287,7 +287,7 @@ Controller.prototype.refresh = function(strips) {
         }
         // build a buffer of the approiate size
         var packetLength = sequenceDenotationLength + totalPixelDataLength;
-        packet = new Buffer(packetLength);
+        packet = Buffer.alloc(packetLength);
         // initialize the buffer with all 0's
         packet.fill(0x00);
 

--- a/pixelstrip.js
+++ b/pixelstrip.js
@@ -29,7 +29,7 @@ module.exports = function(stripId, numPixels) {
     this.getStripData = function(){
         var strip = {
             strip_id : STRIP_ID,
-            data : new Buffer(3 * NUM_PIXELS)
+            data : Buffer.alloc(3 * NUM_PIXELS)
         }
         // fill the buffer with off pixels
         strip.data.fill(0x00);


### PR DESCRIPTION
Changes from @arthelon 's [PR #2 ](https://github.com/ajones/node-pixelpusher/pull/2):

- Adds check to ignore undefined strip slots while refreshing strip data
- Adds .clear() method to PixelStrip, which sets all pixels to color (0, 0, 0, 0), and .clearStrips() to the PixelPusher controller which clears every strip on the controller.

Additional changes:

- Remove buffertools dep entirely.
- Update Buffer calls to suppress deprecation warnings. 

Changes should keep this module stable for some time.